### PR TITLE
複数画像のアップロード

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@
 /config/master.key
 
 .idea
+
+/public/uploads/*

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'turbolinks', '~> 5'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
+gem 'carrierwave'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
@@ -46,7 +47,6 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
-
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,12 +42,21 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     arel (9.0.0)
     bindex (0.8.1)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     builder (3.2.4)
     byebug (11.1.1)
+    carrierwave (2.0.2)
+      activemodel (>= 5.0.0)
+      activesupport (>= 5.0.0)
+      addressable (~> 2.6)
+      image_processing (~> 1.1)
+      mimemagic (>= 0.3.0)
+      mini_mime (>= 0.1.3)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -70,6 +79,9 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    image_processing (1.10.3)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -83,6 +95,7 @@ GEM
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
     mimemagic (0.3.4)
+    mini_magick (4.10.1)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -90,6 +103,7 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.7)
       mini_portile2 (~> 2.4.0)
+    public_suffix (4.0.3)
     puma (3.12.2)
     rack (2.2.0)
     rack-test (1.1.0)
@@ -139,6 +153,8 @@ GEM
       rspec-mocks (~> 3.9.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
+    ruby-vips (2.0.17)
+      ffi (~> 1.9)
     ruby_dep (1.5.0)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
@@ -188,6 +204,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
+  carrierwave
   coffee-rails (~> 4.2)
   factory_bot_rails
   listen (>= 3.0.5, < 3.2)
@@ -207,4 +224,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/app/controllers/albums_controller.rb
+++ b/app/controllers/albums_controller.rb
@@ -53,6 +53,6 @@ class AlbumsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def album_params
-      params.require(:album).permit(:title)
+      params.require(:album).permit(:title, { images: [] })
     end
 end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,3 +1,4 @@
 class Album < ApplicationRecord
+  mount_uploaders :images, ImagesUploader
   validates :title, presence: true
 end

--- a/app/models/album.rb
+++ b/app/models/album.rb
@@ -1,4 +1,5 @@
 class Album < ApplicationRecord
   mount_uploaders :images, ImagesUploader
+  serialize :images, JSON
   validates :title, presence: true
 end

--- a/app/uploaders/images_uploader.rb
+++ b/app/uploaders/images_uploader.rb
@@ -1,0 +1,47 @@
+class ImagesUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/uploaders/images_uploader.rb
+++ b/app/uploaders/images_uploader.rb
@@ -35,9 +35,9 @@ class ImagesUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_whitelist
+    %w[jpg png]
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -18,7 +18,7 @@
 
   <div class="field">
     <%= form.label :images %>
-    <%= form.file_field :images, multiple: true %>
+    <%= form.file_field :images, multiple: true, accept: 'image/jpg,image/png' %>
   </div>
 
   <div class="actions">

--- a/app/views/albums/_form.html.erb
+++ b/app/views/albums/_form.html.erb
@@ -16,6 +16,11 @@
     <%= form.text_field :title %>
   </div>
 
+  <div class="field">
+    <%= form.label :images %>
+    <%= form.file_field :images, multiple: true %>
+  </div>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/albums/show.html.erb
+++ b/app/views/albums/show.html.erb
@@ -5,5 +5,9 @@
   <%= @album.title %>
 </p>
 
+<% @album.images.each do |image| %>
+  <div><%= image_tag image.url %></div>
+<% end %>
+
 <%= link_to 'Edit', edit_album_path(@album) %> |
 <%= link_to 'Back', albums_path %>

--- a/db/migrate/20200212080007_add_images_to_albums.rb
+++ b/db/migrate/20200212080007_add_images_to_albums.rb
@@ -1,0 +1,5 @@
+class AddImagesToAlbums < ActiveRecord::Migration[5.2]
+  def change
+    add_column :albums, :images, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,18 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_09_112310) do
+ActiveRecord::Schema.define(version: 2020_02_12_080007) do
 
   create_table "albums", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.json "images"
   end
 
   create_table "posts", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "image"
   end
 
 end


### PR DESCRIPTION
## 所要時間
c81ea4a まで　1h

## この課題を通して気づいたこと

- 画像複数アップロード機能のやり方
- `file_field multiple: true`の挙動

## どのような方針で実装したか

carrierwaveに複数画像アップロード機能があることは知っていたので、githubのチュートリアルを見ながら実装した。
`multiple: true`によって「ファイル選択」で複数選択ができるようになる状態というのがよくわかっておらず、「ファイル選択」が一つしか表示されていないぞ？となった。（ファイル選択のボタンが複数出てくるのかと思っていた）

## 改善させたい点など

今回とりあえず要件を最低限満たすだけのものを実装した。
現在は、編集画面で画像をアップロードしたときは上書き保存 or 画像をアップロードしない場合は変更なし
なので、
編集画面でアップロードする場合は追加で保存し、削除する場合は個別に削除できるようにしたい。
その場合は、削除は同じ編集フォームでするより別の画面を用意した方がいいのかな？と思っている。